### PR TITLE
chore: promote nodeapp to version 0.0.3

### DIFF
--- a/config-root/namespaces/jx-staging/nodeapp/nodeapp-nodeapp-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodeapp/nodeapp-nodeapp-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodeapp-nodeapp
   labels:
     draft: draft-app
-    chart: "nodeapp-0.0.2"
+    chart: "nodeapp-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'nodeapp'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: nodeapp-nodeapp
       containers:
         - name: nodeapp
-          image: "ghcr.io/sk-sharif/nodeapp:0.0.2"
+          image: "ghcr.io/sk-sharif/nodeapp:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.2
+              value: 0.0.3
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/nodeapp/nodeapp-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodeapp/nodeapp-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodeapp
   labels:
-    chart: "nodeapp-0.0.2"
+    chart: "nodeapp-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'nodeapp'

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> nodeapp </a></td>
-	      <td>0.0.2</td>
+	      <td>0.0.3</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -199,13 +199,13 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.2
+    appVersion: 0.0.3
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-11-03T09:49:27Z"
+    firstDeployed: "2021-11-03T10:11:44Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2021-11-03T09:49:27Z"
+    lastDeployed: "2021-11-03T10:11:44Z"
     name: nodeapp
     repositoryName: dev
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-staging/nodeapp
-    version: 0.0.2
+    version: 0.0.3

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
 releases:
 - chart: dev/nodeapp
-  version: 0.0.2
+  version: 0.0.3
   name: nodeapp
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodeapp to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
